### PR TITLE
Retry for intermittent error codes

### DIFF
--- a/get_branch_protections.py
+++ b/get_branch_protections.py
@@ -495,7 +495,8 @@ def process_orgs(args=None, collected_as=None):
             "Starting on org %s." " (calls remaining %s).", org, ratelimit_remaining()
         )
         global org_queue
-        org_queue = DeferredRetryQueue(retry_codes=[202])
+        # Accept (assumed transitory) GitHub glitch codes as retry requests
+        org_queue = DeferredRetryQueue(retry_codes=[202, 403, 502])
         try:
             db = None
             db = db_setup(org)


### PR DESCRIPTION
GitHub sometimes returns HTTP codes 403 or 502, which previously failed
the entire run.

Current assumption is that these are indicative of transient conditions
on the GitHub side, so just treat as a retry request. We limit the
number of retries, so this does not become an infinite loop.

Unfortunately, since it is a "production only" error, we'll have to go
live and wait for results.