### PR TITLE
Gh 54 fetch failures

### DIFF
--- a/get_branch_protections.py
+++ b/get_branch_protections.py
@@ -553,6 +553,9 @@ if __name__ == "__main__":
         level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
     )
     # setup backoff logging
+    import subprocess
+
+    subprocess.run("pip3 freeze".split())
     logging.getLogger("backoff").addHandler(logging.StreamHandler())
 
     # go to debug on agithub, so we can get a sense of any backoff

--- a/get_branch_protections.py
+++ b/get_branch_protections.py
@@ -553,9 +553,6 @@ if __name__ == "__main__":
         level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
     )
     # setup backoff logging
-    import subprocess
-
-    subprocess.run("pip3 freeze".split())
     logging.getLogger("backoff").addHandler(logging.StreamHandler())
 
     # go to debug on agithub, so we can get a sense of any backoff

--- a/moz_scripts/Makefile
+++ b/moz_scripts/Makefile
@@ -122,13 +122,13 @@ s3_upload:
 		s3_dir=$$(ls -dt /tmp/$${USER}-GitHub-Audit-S3-* | head -1) && \
 		pushd $$s3_dir && \
 		for f in *db.json; do \
-		    aws --profile cloudservices-aws-stage s3 cp $$f s3://foxsec-metrics/github/raw/ ; \
+		    aws --profile cloudservices-aws-stage s3 cp --quiet $$f s3://foxsec-metrics/github/raw/ ; \
 		done && \
 		for f in *db.arr.json; do \
-		    aws --profile cloudservices-aws-stage s3 cp $$f s3://foxsec-metrics/github/array_json/ ; \
+		    aws --profile cloudservices-aws-stage s3 cp --quiet $$f s3://foxsec-metrics/github/array_json/ ; \
 		done && \
 		for f in *db.obj.json; do \
-		    aws --profile cloudservices-aws-stage s3 cp $$f s3://foxsec-metrics/github/object_json/ ; \
+		    aws --profile cloudservices-aws-stage s3 cp --quiet $$f s3://foxsec-metrics/github/object_json/ ; \
 		done && \
 		true \
 		'

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,25 +3,22 @@ category = "main"
 description = "A lightweight, transparent syntax for REST clients"
 name = "agithub"
 optional = false
-platform = "UNKNOWN"
 python-versions = "*"
-version = "2.1"
+version = "2.2.2"
 
 [[package]]
 category = "main"
 description = "Function decoration for backoff and retry"
 name = "backoff"
 optional = false
-platform = "*"
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.10.0"
 
 [[package]]
 category = "dev"
 description = "A full-screen, console-based Python debugger"
 name = "pudb"
 optional = false
-platform = "*"
 python-versions = "*"
 version = "2018.1"
 
@@ -34,16 +31,14 @@ category = "dev"
 description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
-platform = "any"
-python-versions = "*"
-version = "2.3.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.5.2"
 
 [[package]]
 category = "main"
 description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
-platform = "Any"
 python-versions = "*"
 version = "3.13"
 
@@ -52,29 +47,26 @@ category = "main"
 description = "TinyDB is a tiny, document oriented database optimized for your happiness :)"
 name = "tinydb"
 optional = false
-platform = "*"
 python-versions = "*"
-version = "3.12.2"
+version = "3.15.1"
 
 [[package]]
 category = "dev"
 description = "A full-featured console (xterm et al.) user interface library"
 name = "urwid"
 optional = false
-platform = "unix-like"
 python-versions = "*"
-version = "2.0.1"
+version = "2.1.0"
 
 [metadata]
 content-hash = "c96bed3b5f8535342884233a17a87744cfe1bd34410e3b4a5013ff71a13948ff"
-platform = "*"
 python-versions = "^3.6"
 
 [metadata.hashes]
-agithub = ["92b736276efc232c78e4f1705458a5bd82397d3035af31dba13141129fddd413"]
-backoff = ["c7187f15339e775aec926dc6e5e42f8a3ad7d3c2b9a6ecae7b535000f70cd838", "d340bb6f36d025c04214b8925112d8456970e5f28dda46e4f1133bf5c622cb0a"]
+agithub = ["321aa5fc688fde2970562b35c991881b69a13f57372d554a0fab184df85fa8a7", "5f50071536db0cc9611859e761d7c3dc6f951a8535029bf6af7fb22744b7e118"]
+backoff = ["5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd", "b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4"]
 pudb = ["8d8b974641b7a7a2a721af01c9dce5eac8e05a2ceebc2680725ba8eef1ca876e"]
-pygments = ["5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a", "e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"]
+pygments = ["2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b", "98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"]
 pyyaml = ["3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b", "3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf", "40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a", "558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3", "a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1", "aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1", "bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613", "d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04", "d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f", "e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537", "e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"]
-tinydb = ["24b3d4a9611e9953fd57caf063ede6d20abfa0886289fa251f5933082c605dca", "54f6b52fc9bc8378ea29b60e8d93c58f0f4b580a0a3b345810fbc2375baa7655"]
-urwid = ["644d3e3900867161a2fc9287a9762753d66bd194754679adb26aede559bcccbc"]
+tinydb = ["02ef39c07802e3f06e87d3d251f16c44336611fd9ddb4c9fcebf39933f4ba7f3", "804d131d070fc4315beb5821396abe0d84f483e55120dda73f12873ef5c27528"]
+urwid = ["0896f36060beb6bf3801cb554303fef336a79661401797551ba106d23ab4cd86"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-agithub = "^2.1"
+agithub = "^2.2"
 tinydb = "^3.9"
 PyYAML = "^3.12"
 backoff = "^1.6"
@@ -18,7 +18,7 @@ pudb = "^2018.1"
 # Default from https://github.com/ambv/black/blob/master/pyproject.toml
 [tool.black]
 line-length = 88
-py36 = true
+target-version = ['py36',]
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
One semi-smoking gun found -- a function set to backoff on an exception actually raised that exception. So when not a short-term transient error, the failure propagated before recovery could occur.

Various other cleanups done:
- Updated to `agithub` version 2.2, which has built in support for sleep-when-ratelimited
- several previously unseen HTTP status codes are now handled
- `--quiet` added to a number of shell commands to remove progress noise from jenkins console log

This version has had 2 successful runs in staging.